### PR TITLE
Option send change notification to Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ If you want to monitor a page with alert on terminal, use:
 ```
 web-monitoring-app http://google.com
 ```
+**Parameter overview**
+
+| Option       | Shortcut | Type                   | Default | Description                                | Optional |
+|--------------|----------|------------------------|---------|--------------------------------------------|----------|
+| uri          | u        | String                 |         | [URI] to monitor                           | no       |
+| email        | e        | [String String String] |         | [yourEmail] [yourPassword] [receiverEmail] | yes      |
+| telegram     | t        | [String String]        |         | [yourBotIdWithoutBotPrefix] [yourChatId]   | yes      |
+| labse        | l        | Number                 | 5000    |                                            | yes      |
+| percentage   | p        | Number                 |         | percentage of page change (min 0, max 1)   | yes      |
+| loop         | o        | Boolean                | false   | continue after change detection            | yes      |
+| NumberOfTest | n        | Number                 | 10      | number of tests at the beginning           | yes      |
+
 if you want to receive alert on email, use:
 ```
 web-monitoring-app http://google.com -e myname@host.com passwordmyname reciver@host.com
@@ -27,6 +39,11 @@ or
 web-monitoring-app http://google.com -l 5000 -p 0.1 -e myname@host.com passwordmyname reciver@host.com -loop
 Without command -loop, the program stop at first page change
 ```
+**If you like to send you a notification via Telegram**
+```
+web-monitoring-app [uri] -t
+```
+
 **I recommend setting manually percentage of page change with dynamic pages, 0 is the minimum value, 1 is the maximum value**
 ```
 web-monitoring-app http://google.com -p 0.2

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Without command -loop, the program stop at first page change
 ```
 **If you like to send you a notification via Telegram**
 ```
-web-monitoring-app [uri] -t
+web-monitoring-app [uri] -t 123456789:ABCdefOGH1I2Jkl_3nmOp4Q5rstUVwXy6-z 87654321
 ```
+Note: _Use your **bot id without "bot" prefix**! (123456789 instead of bot123456789)_
+Pleace have a look into the [Telegram Bot API](https://core.telegram.org/api#bot-api) how to create a bot and find your chat id.
 
 **I recommend setting manually percentage of page change with dynamic pages, 0 is the minimum value, 1 is the maximum value**
 ```

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sanitize-html": "^1.17.0",
     "valid-url": "^1.0.9",
     "web-monitoring": "^2.1.0",
-    "worker-nodes": "^1.6.0"
+    "worker-nodes": "^1.6.0",
+    "xmlhttprequest": "^1.8.0"
   }
 }

--- a/web-monitoring.js
+++ b/web-monitoring.js
@@ -6,6 +6,7 @@ const vuri = require('valid-url')
 
 const commandLineArgs = require('command-line-args')
 const nodemailer = require('nodemailer')
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 const os = require('os')
 // Use only a core for windows os
 var bp = os.type() !== 'Windows_NT'
@@ -15,10 +16,11 @@ var bp = os.type() !== 'Windows_NT'
 const optionDefinitionsArgs = [
     { name: 'uri', alias: 'u', type: String, defaultOption: true },
     { name: 'email', alias: 'e', multiple: true, type: String },
+    { name: 'telegram', alias: 't', multiple: true, type: String },
     { name: 'lapse', alias: 'l', type: Number, defaultValue: 5000 },
     { name: 'percentage', alias: 'p', type: Number },
     { name: 'loop', alias: 'o', type: Boolean, defaultValue: false },
-    { name: 'NumberOfTest', alias: 't', type: Number, defaultValue: 10 }
+    { name: 'NumberOfTest', alias: 'n', type: Number, defaultValue: 10 }
 ]
 
 var values = commandLineArgs(optionDefinitionsArgs)
@@ -47,6 +49,13 @@ if (values.email && values.email.length === 3) {
     text: `${values.uri} was change`
   }
 }
+// telegram test message
+if (values.telegram && values.telegram.length === 2) {
+                  let telegramUrl = `https://api.telegram.org/bot${values.telegram[0]}/sendMessage?chat_id=${values.telegram[1]}&text=test%20for%20${values.uri}%20monitoring`;
+                  let xhr = new XMLHttpRequest();
+                  xhr.open('GET', telegramUrl+1);
+                  xhr.send();
+                }
 if (values.NumberOfTest <= 0) throw new Error('nTest must be >0')
 if (!values.uri) throw new URIError('Uri is obligatory')
     ; (async function () {
@@ -70,7 +79,15 @@ if (!values.uri) throw new URIError('Uri is obligatory')
                   }
                 })
               } else {
-                console.log(`page ${uri} chaged`)
+                console.log(`page ${uri} changed`)
+
+                // send telegram msg
+                if (values.telegram && values.telegram.length === 2) {
+                  let telegramUrl = `https://api.telegram.org/bot${values.telegram[0]}/sendMessage?chat_id=${values.telegram[1]}&text=PAGE%20CHANGED`;
+                  let xhrAlert = new XMLHttpRequest();
+                  xhrAlert.open('GET', telegramUrl);
+                  xhrAlert.send();
+                }
               }
               if (!values.loop) wp.stop()
             })


### PR DESCRIPTION
Hi.
I prefer to use [Telegram Messenger](https://telegram.org/) sending me notifications. 
It's a 'heavily encrypted' messenger supporting serval platforms and very common.
```
web-monitoring-app [uri] -t [bot id] [chat id]
web-monitoring-app www.google.com -t 123456789:ABCdefOGH1I2Jkl_3nmOp4Q5rstUVwXy6-z 87654321
```
Note: _Use your bot id without "bot" prefix! (123456789 instead of bot123456789)_